### PR TITLE
Fixed fImage::getImageType issue

### DIFF
--- a/fFile.php
+++ b/fFile.php
@@ -5,12 +5,14 @@
  * @copyright  Copyright (c) 2007-2011 Will Bond, others
  * @author     Will Bond [wb] <will@flourishlib.com>
  * @author     Will Bond, iMarc LLC [wb-imarc] <will@imarc.net>
+ * @author     Kevin Hamer, iMarc LLC [kh] <kevin@imarc.net>
  * @license    http://flourishlib.com/license
  * 
  * @package    Flourish
  * @link       http://flourishlib.com/fFile
  * 
- * @version    1.0.0b39
+ * @version    1.0.0b40
+ * @changes    1.0.0b40  Improved ::determineMimeTypeByContents() for text files to focus on the first non-blank line and look for <html. [kh, 2012-07-25]
  * @changes    1.0.0b39  Backwards Compatibility Break - ::output() now automatically ends any open output buffering and discards the contents [wb, 2011-08-24]
  * @changes    1.0.0b38  Added the Countable interface to the class [wb, 2011-06-03]
  * @changes    1.0.0b37  Fixed mime type detection of BMP images [wb, 2011-03-07]

--- a/fFile.php
+++ b/fFile.php
@@ -338,8 +338,15 @@ class fFile implements Iterator, Countable
 		}	
 		
 		
-		// Text files
-		if (strpos($content, '<?xml') !== FALSE) {
+		// Better detection for text files based on the first line or so.
+		if (strpos($content, '<?php') !== FALSE || strpos($content, '<?=') !== FALSE) {
+			return 'application/x-httpd-php';	
+		}
+		
+		preg_match('/(\S.*?)\s*\n/m', $content, $lines);
+		$first_line = count($lines) > 1 ? $lines[1] : '';
+		
+		if (strpos($first_line, '<?xml') !== FALSE) {
 			if (stripos($content, '<!DOCTYPE') !== FALSE) {
 				return 'application/xhtml+xml';
 			}
@@ -349,14 +356,17 @@ class fFile implements Iterator, Countable
 			if (strpos($content, '<rss') !== FALSE) {
 				return 'application/rss+xml';
 			}
-			return 'application/xml';	
-		}   
-		
-		if (strpos($content, '<?php') !== FALSE || strpos($content, '<?=') !== FALSE) {
-			return 'application/x-httpd-php';	
+			return 'application/xml';
 		}
 		
-		if (preg_match('#^\#\![/a-z0-9]+(python|perl|php|ruby)$#mi', $content, $matches)) {
+		if (stripos($first_line, '<html') !== FALSE) {
+			return 'text/html';
+		}
+		if (stripos($first_line, '<!DOCTYPE') !== FALSE) {
+			return 'text/html';
+		}
+		
+		if (preg_match('#^\#\![/a-z0-9]+(python|perl|php|ruby)$#mi', $first_line, $matches)) {
 			switch (strtolower($matches[1])) {
 				case 'php':
 					return 'application/x-httpd-php';

--- a/fImage.php
+++ b/fImage.php
@@ -1,16 +1,18 @@
 <?php
 /**
  * Represents an image on the filesystem, also provides image manipulation functionality
- * 
+ *
  * @copyright  Copyright (c) 2007-2011 Will Bond, others
  * @author     Will Bond [wb] <will@flourishlib.com>
  * @author     Will Bond, iMarc LLC [wb-imarc] <will@imarc.net>
+ * @author     Jeff Turcotte, iMarc LLC [jt] <jeff@imarc.net>
  * @license    http://flourishlib.com/license
- * 
+ *
  * @package    Flourish
  * @link       http://flourishlib.com/fImage
- * 
- * @version    1.0.0b33
+ *
+ * @version    1.0.0b34
+ * @changes    1.0.0b34  Fixed a bug in getImageType() where the fread was not reading enough bytes [jt, 2012-06-05]
  * @changes    1.0.0b33  Fixed a method signature [wb, 2011-08-24]
  * @changes    1.0.0b32  Added a call to clearstatcache() to ::saveChanges() to solve a bug when fFile::output() is called in the same script execution [wb, 2011-05-23]
  * @changes    1.0.0b31  Fixed a bug in using ImageMagick to convert files with a colon in the filename [wb, 2011-03-20]
@@ -370,14 +372,14 @@ class fImage extends fFile
 	
 	/**
 	 * Gets the image type from a file by looking at the file contents
-	 * 
+	 *
 	 * @param  string $image  The image path to get the type for
-	 * @return string|NULL  The type of the image - `'jpg'`, `'gif'`, `'png'` or `'tif'` - NULL if not one of those  
+	 * @return string|NULL  The type of the image - `'jpg'`, `'gif'`, `'png'` or `'tif'` - NULL if not one of those
 	 */
 	static private function getImageType($image)
 	{
 		$handle   = fopen($image, 'r');
-		$contents = fread($handle, 12);
+		$contents = fread($handle, 32);
 		fclose($handle);
 		
 		$_0_8  = substr($contents, 0, 8);
@@ -407,11 +409,11 @@ class fImage extends fFile
 	
 	/**
 	 * Checks to make sure the class can handle the image file specified
-	 * 
+	 *
 	 * @internal
-	 * 
+	 *
 	 * @throws fValidationException  When the image specified does not exist
-	 * 
+	 *
 	 * @param  string $image  The image to check for incompatibility
 	 * @return boolean  If the image is compatible with the detected image processor
 	 */

--- a/fRequest.php
+++ b/fRequest.php
@@ -16,7 +16,8 @@
  * @package    Flourish
  * @link       http://flourishlib.com/fRequest
  * 
- * @version    1.0.0b19
+ * @version    1.0.0b20
+ * @changes    1.0.0b20  Fixed problem where Accept headers are spaced out and mime-types won't match (mainly from IE)
  * @changes    1.0.0b19  Added the `$use_default_for_blank` parameter to ::get() [wb, 2011-06-03]
  * @changes    1.0.0b18  Backwards Compatibility Break - ::getBestAcceptType() and ::getBestAcceptLanguage() now return either `NULL`, `FALSE` or a string instead of `NULL` or a string, both methods are more robust in handling edge cases [wb, 2011-02-06]
  * @changes    1.0.0b17  Fixed support for 3+ dimensional input arrays, added a fixed for the PHP DoS float bug #53632, added support for type-casted arrays in ::get() [wb, 2011-01-09]
@@ -760,7 +761,7 @@ class fRequest
 			}
 			$q .= $suffix--;
 			
-			$output[$parts[0]] = $q;	
+			$output[trim($parts[0])] = $q;	
 		}
 		
 		arsort($output, SORT_NUMERIC);

--- a/fTemplating.php
+++ b/fTemplating.php
@@ -5,12 +5,14 @@
  * @copyright  Copyright (c) 2007-2011 Will Bond, others
  * @author     Will Bond [wb] <will@flourishlib.com>
  * @author     Matt Nowack [mn] <mdnowack@gmail.com>
+ * @author     Jeff Turcotte [jt] <jeff@imarc.net>
  * @license    http://flourishlib.com/license
  * 
  * @package    Flourish
  * @link       http://flourishlib.com/fTemplating
  * 
- * @version    1.0.0b23
+ * @version    1.0.0b24
+ * @changes    1.0.0b24  Added getRootPath() to retrieve the path fTemplating was instantiated with [jt, 2012-10-24]
  * @changes    1.0.0b23  Added a default `$name` for ::retrieve() to mirror ::attach() [wb, 2011-08-31]
  * @changes    1.0.0b22  Backwards Compatibility Break - removed the static method ::create(), added the static method ::attach() to fill its place [wb, 2011-08-31]
  * @changes    1.0.0b21  Fixed a bug in ::enableMinification() where the minification cache directory was sometimes not properly converted to a web path [wb, 2011-08-31]
@@ -710,7 +712,16 @@ class fTemplating
 		
 		return $value;
 	}
-	
+
+	/**
+	 * Gets the root path
+	 *
+	 * @return string  The root path for the instance
+	 */
+	public function getRootPath()
+	{
+		return $this->root;
+	}
 	
 	/**
 	 * Combines an array of CSS or JS files and places them as a single file

--- a/fValidation.php
+++ b/fValidation.php
@@ -4,12 +4,14 @@
  * 
  * @copyright  Copyright (c) 2007-2011 Will Bond
  * @author     Will Bond [wb] <will@flourishlib.com>
+ * @author     Kerri Gertz [kg] <kerri@imarc.net>
  * @license    http://flourishlib.com/license
  * 
  * @package    Flourish
  * @link       http://flourishlib.com/fValidation
  * 
- * @version    1.0.0b12
+ * @version    1.0.0b13
+ * @changes    1.0.0b13  Fixed return bug in ::checkConditionalRules [kg, 2010-06-19]
  * @changes    1.0.0b12  Fixed some method signatures [wb, 2011-08-24]
  * @changes    1.0.0b11  Fixed ::addCallbackRule() to be able to handle multiple rules per field [wb, 2011-06-02]
  * @changes    1.0.0b10  Fixed ::addRegexRule() to be able to handle multiple rules per field [wb, 2010-08-30]
@@ -672,7 +674,7 @@ class fValidation
 			}
 			
 			if (!$check_for_missing_values) {
-				return;	
+				continue;	
 			}
 			
 			foreach ($rule['conditional_fields'] as $conditional_field) {


### PR DESCRIPTION
Changed the # of bytes read in to 32 from 12. 12 was not enough to determine the type for a certain JPEG format. The substr's below were attempting to read bytes that didn't exist.
