### PR TITLE
fImage bug fix

### DIFF
--- a/fImage.php
+++ b/fImage.php
@@ -1,16 +1,18 @@
 <?php
 /**
  * Represents an image on the filesystem, also provides image manipulation functionality
- * 
+ *
  * @copyright  Copyright (c) 2007-2011 Will Bond, others
  * @author     Will Bond [wb] <will@flourishlib.com>
  * @author     Will Bond, iMarc LLC [wb-imarc] <will@imarc.net>
+ * @author     Jeff Turcotte, iMarc LLC [jt] <jeff@imarc.net>
  * @license    http://flourishlib.com/license
- * 
+ *
  * @package    Flourish
  * @link       http://flourishlib.com/fImage
- * 
- * @version    1.0.0b33
+ *
+ * @version    1.0.0b34
+ * @changes    1.0.0b34  Fixed a bug in getImageType() where the fread was not reading enough bytes [jt, 2012-06-05]
  * @changes    1.0.0b33  Fixed a method signature [wb, 2011-08-24]
  * @changes    1.0.0b32  Added a call to clearstatcache() to ::saveChanges() to solve a bug when fFile::output() is called in the same script execution [wb, 2011-05-23]
  * @changes    1.0.0b31  Fixed a bug in using ImageMagick to convert files with a colon in the filename [wb, 2011-03-20]
@@ -370,14 +372,14 @@ class fImage extends fFile
 	
 	/**
 	 * Gets the image type from a file by looking at the file contents
-	 * 
+	 *
 	 * @param  string $image  The image path to get the type for
-	 * @return string|NULL  The type of the image - `'jpg'`, `'gif'`, `'png'` or `'tif'` - NULL if not one of those  
+	 * @return string|NULL  The type of the image - `'jpg'`, `'gif'`, `'png'` or `'tif'` - NULL if not one of those
 	 */
 	static private function getImageType($image)
 	{
 		$handle   = fopen($image, 'r');
-		$contents = fread($handle, 12);
+		$contents = fread($handle, 32);
 		fclose($handle);
 		
 		$_0_8  = substr($contents, 0, 8);
@@ -407,11 +409,11 @@ class fImage extends fFile
 	
 	/**
 	 * Checks to make sure the class can handle the image file specified
-	 * 
+	 *
 	 * @internal
-	 * 
+	 *
 	 * @throws fValidationException  When the image specified does not exist
-	 * 
+	 *
 	 * @param  string $image  The image to check for incompatibility
 	 * @return boolean  If the image is compatible with the detected image processor
 	 */


### PR DESCRIPTION
Certain types of JPEG's could not be read. Increased the byte read limit.

Minor whitespace changes. Line 380 is where the real change occurred.
