### PR TITLE
Fix function misspell in fSchema

### DIFF
--- a/fSchema.php
+++ b/fSchema.php
@@ -3076,7 +3076,7 @@ class fSchema
 	 */
 	public function setColumnInfoOverride($column_info, $table, $column=NULL)
 	{
-		$table = strotlower($table);
+		$table = strtolower($table);
 		if ($column !== NULL) {
 			$column = strtolower($column);
 		}


### PR DESCRIPTION
I dont' believe that someone is here, but who knows?

For those, who will have same issue, workaround is to add this:

```
if (!function_exists('strotlower')) {function strotlower($str) {return strtolower($str);}}
```
