### PR TITLE
Fix infinite loop issue with non-closed connections

### DIFF
--- a/fMailbox.php
+++ b/fMailbox.php
@@ -1406,7 +1406,7 @@ class fMailbox
 		}
 
 		if ($select) {
-			while (!feof($this->connection)) {
+			do {
 				$line = fgets($this->connection);
 				if ($line === FALSE) {
 					break;
@@ -1433,7 +1433,7 @@ class fMailbox
 						break;
 					}
 				}
-			}
+			} while (!feof($this->connection));
 		}
 		if (fCore::getDebug($this->debug)) {
 			fCore::debug("Received:\n" . join("\r\n", $response), $this->debug);


### PR DESCRIPTION
With some server configurations (I couldn't tell what exactly), the problem of the infinite loop caused by the use of `feof()` with a connection opened with `fsockopen()` and _not being closed by the server_ as explained on the [PHP manual page of the function](http://php.net/manual/en/function.feof.php#refsect1-function.feof-notes) happens. This results in the process not being completed, the e-mails aren't checked and it can actually lead to a 504 error.

In order to fix that, I have replaced the `while` loop by a `do {} while();` so that the end of the resource `$this->connection` is actually processed and the correct value is returned, allowing the function to continue its process.
