### PR TITLE
Removed "!is_numeric($json)"

### DIFF
--- a/fJSON.php
+++ b/fJSON.php
@@ -283,7 +283,7 @@ class fJSON
 	 */
 	static public function decode($json, $assoc=FALSE)
 	{
-		if (!is_string($json) && !is_numeric($json)) {
+		if (!is_string($json)) {
 			return NULL;
 		}
 


### PR DESCRIPTION
I removed "!is_numeric($json)" because otherwise e.g. this JSON data are not parsed:

{
 "query": {
  "count": 2,
  "created": "2015-09-10T07:09:20Z",
  "lang": "en-US",
  "results": {
   "rate": [
    {
     "id": "EURUSD",
     "Name": "EUR/USD",
     "Rate": "1.1215",
     "Date": "9/10/2015",
     "Time": "8:09am",
     "Ask": "1.1220",
     "Bid": "1.1210"
    },
    {
     "id": "EURGBP",
     "Name": "EUR/GBP",
     "Rate": "0.7304",
     "Date": "9/10/2015",
     "Time": "8:09am",
     "Ask": "0.7307",
     "Bid": "0.7300"
    }
   ]
  }
 }
}
