### PR TITLE
adds regex support for E notation floats

### DIFF
--- a/fDatabase.php
+++ b/fDatabase.php
@@ -1283,7 +1283,7 @@ class fDatabase
 		if (!strlen($value)) {
 			return 'NULL';
 		}
-		if (!preg_match('#^[+\-]?([0-9]+(\.([0-9]+)?)?|(\.[0-9]+))$#D', $value)) {
+		if (!preg_match('#^[+\-]?([0-9]+(\.([0-9]+)?)?([Ee][+\-]?[0-9]+)?|(\.[0-9]+))$#D', $value)) {
 			return 'NULL';
 		}
 


### PR DESCRIPTION
When dealing with very large or very small floats, php 5.6 will store it as an E notation float (i.e., `1.001e-9`). fDatabase::escapeFloat() converts this to `'NULL'`.